### PR TITLE
Fix app startup crash caused by missing geoalchemy dependency

### DIFF
--- a/app/blueprints/yacimiento.py
+++ b/app/blueprints/yacimiento.py
@@ -7,9 +7,6 @@ from app.utils import generar_codigo_unico, allowed_file, is_safe_url, time_ago
 from werkzeug.utils import secure_filename
 import os
 import json
-from geoalchemy2.shape import to_shape
-from shapely.geometry import mapping
-
 yacimiento_bp = Blueprint('yacimiento', __name__)
 
 @yacimiento_bp.route('/nuevo_yacimiento', methods=['GET', 'POST'])


### PR DESCRIPTION
### Motivation
- The app failed to initialize in environments without `geoalchemy2`/`shapely` because those packages were imported at module load time but not actually used in the blueprint.

### Description
- Removed the unused imports `from geoalchemy2.shape import to_shape` and `from shapely.geometry import mapping` from `app/blueprints/yacimiento.py` to avoid import-time failures.

### Testing
- Ran `python -m compileall -q app run.py main.py config.py` which completed successfully.
- Ran a small check that imports the application with `from app import create_app` and verified it prints `create_app OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698781082670832aa15389851adba75f)