### PR TITLE
Fix auth template paths and remove unused geoalchemy/shapely imports

### DIFF
--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -33,7 +33,7 @@ def registro():
         except Exception as e:
             db.session.rollback()
             flash(f'Error al registrar: {str(e)}', 'error')
-    return render_template('auth/registro.html', form=form)
+    return render_template('registro.html', form=form)
 
 @auth_bp.route('/iniciar-sesion', methods=['GET', 'POST'])
 def iniciar_sesion():
@@ -51,7 +51,7 @@ def iniciar_sesion():
                 return redirect(next_page)
             return redirect(url_for('main.inicio'))
         flash('Credenciales inválidas', 'error')
-    return render_template('auth/iniciar_sesion.html', form=form)
+    return render_template('iniciar_sesion.html', form=form)
 
 @auth_bp.route('/cerrar-sesion')
 @login_required

--- a/app/blueprints/yacimiento.py
+++ b/app/blueprints/yacimiento.py
@@ -7,9 +7,6 @@ from app.utils import generar_codigo_unico, allowed_file, is_safe_url, time_ago
 from werkzeug.utils import secure_filename
 import os
 import json
-from geoalchemy2.shape import to_shape
-from shapely.geometry import mapping
-
 yacimiento_bp = Blueprint('yacimiento', __name__)
 
 @yacimiento_bp.route('/nuevo_yacimiento', methods=['GET', 'POST'])


### PR DESCRIPTION
### Motivation
- Prevent template lookup errors from incorrect template path references in the auth blueprint.
- Avoid import-time crashes in environments lacking `geoalchemy2`/`shapely` by removing unused imports from the yacimiento blueprint.

### Description
- Updated `app/blueprints/auth.py` to render `registro.html` and `iniciar_sesion.html` from the templates root instead of `auth/registro.html` and `auth/iniciar_sesion.html`.
- Removed the unused imports `from geoalchemy2.shape import to_shape` and `from shapely.geometry import mapping` from `app/blueprints/yacimiento.py` to stop import-time failures when those optional packages are not installed.
- Minor whitespace/file-end adjustment in `app/blueprints/auth.py` to match project formatting.

### Testing
- Ran `python -m compileall -q app run.py main.py config.py` which completed successfully.
- Ran a project-wide template-reference check script that reported `missing 0`, confirming all `render_template()` calls point to existing template files.
- Removed `__pycache__` directories and verified the working tree contains only the intended changes; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698781082670832aa15389851adba75f)