### PR TITLE
Fix route/template mismatches and permission/context issues for yacimientos & sectores

### DIFF
--- a/app/blueprints/sector.py
+++ b/app/blueprints/sector.py
@@ -55,21 +55,33 @@ def listar(yacimiento_id):
     ).first():
         abort(403)
 
-    puede_crear = yacimiento.user_id == current_user.id or Invitacion.query.filter_by(
+    invitacion_aceptada = Invitacion.query.filter_by(
         yacimiento_id=yacimiento_id,
         invitado_id=current_user.id,
         estado='aceptada'
-    ).filter(Invitacion.rol.in_(['colaborador', 'asistente'])).first()
+    ).first()
+
+    puede_crear = yacimiento.user_id == current_user.id or (
+        invitacion_aceptada and invitacion_aceptada.rol in ['colaborador', 'asistente']
+    )
+    puede_editar_sectores = yacimiento.user_id == current_user.id or (
+        invitacion_aceptada and invitacion_aceptada.rol in ['editor', 'asistente']
+    )
+    puede_eliminar_sectores = yacimiento.user_id == current_user.id
 
     sectores = Sector.query.filter_by(yacimiento_id=yacimiento_id).all()
     sectores_json = [s.to_dict() for s in sectores]
+    total_hallazgos = sum(s.hallazgos.count() for s in sectores)
 
     return render_template(
         'sectores/listar.html',
         yacimiento=yacimiento,
         sectores=sectores,
         sectores_json=sectores_json,
-        puede_crear=puede_crear
+        puede_crear=puede_crear,
+        puede_editar_sectores=puede_editar_sectores,
+        puede_eliminar_sectores=puede_eliminar_sectores,
+        total_hallazgos=total_hallazgos
     )
 
 @sector_bp.route('/yacimiento/<int:yacimiento_id>/mapa_sectores')

--- a/app/blueprints/yacimiento.py
+++ b/app/blueprints/yacimiento.py
@@ -41,12 +41,26 @@ def detalle(yacimiento_id):
     """Detalle del yacimiento"""
     yacimiento = Yacimiento.query.get_or_404(yacimiento_id)
 
+    invitacion_aceptada = Invitacion.query.filter_by(
+        yacimiento_id=yacimiento_id,
+        invitado_id=current_user.id,
+        estado='aceptada'
+    ).first()
+
+    if yacimiento.user_id != current_user.id and not invitacion_aceptada:
+        abort(403)
+
     # Verificar acceso
     puede_editar = yacimiento.user_id == current_user.id or Invitacion.query.filter_by(
         yacimiento_id=yacimiento_id,
         invitado_id=current_user.id,
         estado='aceptada',
         rol='asistente'
+    ).first() or Invitacion.query.filter_by(
+        yacimiento_id=yacimiento_id,
+        invitado_id=current_user.id,
+        estado='aceptada',
+        rol='editor'
     ).first()
 
     puede_crear = yacimiento.user_id == current_user.id or Invitacion.query.filter_by(
@@ -58,6 +72,13 @@ def detalle(yacimiento_id):
     hallazgos = Hallazgo.query.filter_by(yacimiento_id=yacimiento_id).all()
     sectores = Sector.query.filter_by(yacimiento_id=yacimiento_id).all()
     fases = FaseProyecto.query.filter_by(yacimiento_id=yacimiento_id).all()
+    es_propietario = yacimiento.user_id == current_user.id
+    rol_usuario = 'propietario' if es_propietario else (invitacion_aceptada.rol if invitacion_aceptada else None)
+    total_hallazgos = len(hallazgos)
+    total_sectores = len(sectores)
+    total_fases = len(fases)
+    hallazgos_con_foto = sum(1 for h in hallazgos if h.foto)
+    sectores_json = [s.to_dict() for s in sectores]
 
     return render_template(
         'yacimientos/detalle.html',
@@ -66,7 +87,14 @@ def detalle(yacimiento_id):
         sectores=sectores,
         fases=fases,
         puede_editar=puede_editar,
-        puede_crear=puede_crear
+        puede_crear=puede_crear,
+        es_propietario=es_propietario,
+        rol_usuario=rol_usuario,
+        total_hallazgos=total_hallazgos,
+        total_sectores=total_sectores,
+        total_fases=total_fases,
+        hallazgos_con_foto=hallazgos_con_foto,
+        sectores_json=sectores_json
     )
 
 @yacimiento_bp.route('/editar_yacimiento/<int:yacimiento_id>', methods=['GET', 'POST'])

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,8 +31,8 @@
                 {% if current_user.is_authenticated %}
                     <li><a href="/inicio" class="nav-link">Inicio</a></li>
                     <li><a href="/nuevo_yacimiento" class="nav-link">Nuevo Yacimiento</a></li>
-                    <li><a href="/buscar-codigo" class="nav-link">Buscar Código</a></li>
-                    <li><a href="/mis-invitaciones" class="nav-link">Invitaciones</a></li>
+                    <li><a href="/buscar_codigo" class="nav-link">Buscar Código</a></li>
+                    <li><a href="/mis_invitaciones" class="nav-link">Invitaciones</a></li>
                     <li><a href="/perfil" class="nav-link">Mi Perfil</a></li>
                     <li><a href="/cerrar-sesion" class="nav-link btn-nav-primary">Cerrar Sesión</a></li>
                 {% else %}

--- a/templates/eventos/timeline.html
+++ b/templates/eventos/timeline.html
@@ -88,8 +88,8 @@
                     </div>
 
                     <div style="margin-top: 1rem; display: flex; gap: 0.5rem;">
-                        <a href="/evento/{{ evento.id }}/editar" class="btn btn-secondary" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
-                        <form method="POST" action="/evento/{{ evento.id }}/eliminar" style="display: inline;" onsubmit="return confirm('¿Eliminar este evento?');">
+                        <a href="/editar_evento/{{ evento.id }}" class="btn btn-secondary" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
+                        <form method="POST" action="/eliminar_evento/{{ evento.id }}" style="display: inline;" onsubmit="return confirm('¿Eliminar este evento?');">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-danger" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Eliminar</button>
                         </form>

--- a/templates/fases/detalle.html
+++ b/templates/fases/detalle.html
@@ -17,9 +17,9 @@
                 </p>
             </div>
             <div class="button-group" style="margin: 0;">
-                <a href="/fase/{{ fase.id }}/editar" class="btn">Editar</a>
+                <a href="/editar_fase/{{ fase.id }}" class="btn">Editar</a>
                 <a href="/yacimiento/{{ fase.yacimiento_id }}/fases" class="btn btn-secondary">Volver a Fases</a>
-                <form method="POST" action="/fase/{{ fase.id }}/eliminar" style="display: inline;" onsubmit="return confirm('¿Estás seguro de eliminar esta fase?');">
+                <form method="POST" action="/eliminar_fase/{{ fase.id }}" style="display: inline;" onsubmit="return confirm('¿Estás seguro de eliminar esta fase?');">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-danger">Eliminar Fase</button>
         </form>

--- a/templates/fases/listar.html
+++ b/templates/fases/listar.html
@@ -72,7 +72,7 @@
 
                         <div style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
                             <a href="/fase/{{ fase.id }}" class="btn btn-secondary" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Ver Detalles</a>
-                            <a href="/fase/{{ fase.id }}/editar" class="btn" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
+                            <a href="/editar_fase/{{ fase.id }}" class="btn" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
 
                             {% if not loop.first %}
                                 <form method="POST" action="/fase/{{ fase.id }}/cambiar_orden/arriba" style="display: inline;">
@@ -88,7 +88,7 @@
                                 </form>
                             {% endif %}
 
-                            <form method="POST" action="/fase/{{ fase.id }}/eliminar" style="display: inline;" onsubmit="return confirm('¿Eliminar esta fase?');">
+                            <form method="POST" action="/eliminar_fase/{{ fase.id }}" style="display: inline;" onsubmit="return confirm('¿Eliminar esta fase?');">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-danger" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Eliminar</button>
                             </form>

--- a/templates/hallazgos/detalle.html
+++ b/templates/hallazgos/detalle.html
@@ -143,10 +143,10 @@
     <div class="card">
         <h2 style="margin-bottom: 1.5rem; border: none;">Comentarios ({{ comentarios|length }})</h2>
 
-        <form method="POST" action="/agregar_comentario/{{ hallazgo.id }}" style="margin-bottom: 2rem;">
-            {{ formulario_comentario.hidden_tag() }}
+        <form method="POST" action="/comentar_hallazgo/{{ hallazgo.id }}" style="margin-bottom: 2rem;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="form-group">
-                {{ formulario_comentario.texto(class="form-control", rows=3, placeholder="Escribe un comentario...") }}
+                <textarea name="texto" class="form-control" rows="3" placeholder="Escribe un comentario..." required></textarea>
             </div>
             <button type="submit" class="btn btn-success">Publicar Comentario</button>
         </form>

--- a/templates/invitaciones/gestionar.html
+++ b/templates/invitaciones/gestionar.html
@@ -56,7 +56,7 @@
                         </div>
 
                         {% if invitacion.estado == 'pendiente' %}
-                        <form method="POST" action="/invitacion/{{ invitacion.id }}/cancelar" style="display: inline;" onsubmit="return confirm('¿Cancelar esta invitación?');">
+                        <form method="POST" action="/revocar_invitacion/{{ invitacion.id }}" style="display: inline;" onsubmit="return confirm('¿Cancelar esta invitación?');">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="btn btn-danger" style="padding: 0.5rem 1rem;">
                                 Cancelar Invitación

--- a/templates/invitaciones/mis_invitaciones.html
+++ b/templates/invitaciones/mis_invitaciones.html
@@ -32,13 +32,13 @@
                         </div>
 
                         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                            <form method="POST" action="/invitacion/{{ invitacion.id }}/aceptar" style="display: inline;">
+                            <form method="POST" action="/aceptar_invitacion/{{ invitacion.id }}" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-success">
                                     Aceptar
                                 </button>
                             </form>
-                            <form method="POST" action="/invitacion/{{ invitacion.id }}/rechazar" style="display: inline;">
+                            <form method="POST" action="/rechazar_invitacion/{{ invitacion.id }}" style="display: inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-danger">
                                     Rechazar

--- a/templates/perfil.html
+++ b/templates/perfil.html
@@ -63,7 +63,7 @@
         </div>
         <div class="button-group" style="margin-top: 2rem;">
             <a href="/inicio" class="btn">← Volver al Dashboard</a>
-            <form action="{{ url_for('eliminar_cuenta') }}" method="post" style="display:inline;" onsubmit="return confirm('⚠️ ¿Estás seguro de eliminar tu cuenta?\n\nEsta acción eliminará:\n- Todos tus yacimientos\n- Todos tus hallazgos\n- Todos tus comentarios\n\nEsta acción NO se puede deshacer.')">
+            <form action="{{ url_for('main.eliminar_cuenta') }}" method="post" style="display:inline;" onsubmit="return confirm('⚠️ ¿Estás seguro de eliminar tu cuenta?\n\nEsta acción eliminará:\n- Todos tus yacimientos\n- Todos tus hallazgos\n- Todos tus comentarios\n\nEsta acción NO se puede deshacer.')">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-danger">Eliminar mi cuenta</button>
             </form>

--- a/templates/sectores/detalle.html
+++ b/templates/sectores/detalle.html
@@ -22,7 +22,7 @@
                 {% endif %}
             </div>
             <div class="button-group" style="margin: 0;">
-                <a href="/sector/{{ sector.id }}/editar" class="btn">Editar</a>
+                <a href="/editar_sector/{{ sector.id }}" class="btn">Editar</a>
                 <a href="/yacimiento/{{ sector.yacimiento_id }}/sectores" class="btn btn-secondary">Volver a Sectores</a>
             </div>
         </div>

--- a/templates/sectores/listar.html
+++ b/templates/sectores/listar.html
@@ -13,10 +13,10 @@
             <h1>Sectores del Yacimiento ({{ sectores|length }})</h1>
             <div class="button-group" style="margin: 0;">
                 {% if puede_crear %}
-                    <a href="{{ url_for('nuevo_sector', yacimiento_id=yacimiento.id) }}" class="btn btn-success">➕ Nuevo Sector</a>
+                    <a href="{{ url_for('sector.nuevo_sector', yacimiento_id=yacimiento.id) }}" class="btn btn-success">➕ Nuevo Sector</a>
                 {% endif %}
                 {% if sectores %}
-                    <a href="{{ url_for('mapa_sectores', yacimiento_id=yacimiento.id) }}" class="btn btn-info">🗺️ Ver Mapa</a>
+                    <a href="{{ url_for('sector.mapa_sectores', yacimiento_id=yacimiento.id) }}" class="btn btn-info">🗺️ Ver Mapa</a>
                 {% endif %}
             </div>
         </div>
@@ -37,7 +37,7 @@
                 </div>
 
                 <div class="stat-card" style="background: linear-gradient(135deg, var(--info-color), #2563eb);">
-                    <h3>{{ sectores|sum(attribute='hallazgos')|length if sectores else 0 }}</h3>
+                    <h3>{{ total_hallazgos }}</h3>
                     <p>Hallazgos Totales</p>
                 </div>
 
@@ -106,12 +106,12 @@
                         </div>
 
                         <div class="card-actions">
-                            <a href="{{ url_for('detalle_sector', sector_id=sector.id) }}" class="btn">Ver Detalles</a>
-                            {% if puede_editar %}
-                                <a href="{{ url_for('editar_sector', sector_id=sector.id) }}" class="btn btn-secondary">Editar</a>
+                            <a href="{{ url_for('sector.detalle', sector_id=sector.id) }}" class="btn">Ver Detalles</a>
+                            {% if puede_editar_sectores %}
+                                <a href="{{ url_for('sector.editar', sector_id=sector.id) }}" class="btn btn-secondary">Editar</a>
                             {% endif %}
-                            {% if puede_eliminar %}
-                                <form method="POST" action="{{ url_for('eliminar_sector', sector_id=sector.id) }}"
+                            {% if puede_eliminar_sectores %}
+                                <form method="POST" action="{{ url_for('sector.eliminar', sector_id=sector.id) }}"
                                       style="display: inline;" 
                                       onsubmit="return confirm('¿Eliminar sector \"{{ sector.nombre }}\"? Los hallazgos quedarán sin asignar.');">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -128,14 +128,14 @@
                 <h3>No hay sectores registrados</h3>
                 <p style="color: var(--gray); margin-bottom: 2rem;">Divide el yacimiento en sectores para organizar mejor los hallazgos</p>
                 {% if puede_crear %}
-                    <a href="{{ url_for('nuevo_sector', yacimiento_id=yacimiento.id) }}" class="btn btn-success btn-lg">
+                    <a href="{{ url_for('sector.nuevo_sector', yacimiento_id=yacimiento.id) }}" class="btn btn-success btn-lg">
                         ➕ Crear Primer Sector
                     </a>
                 {% endif %}
             </div>
         {% endif %}
 
-        <a href="{{ url_for('detalle_yacimiento', id=yacimiento.id) }}" class="btn btn-secondary" style="margin-top: 2rem;">← Volver al Yacimiento</a>
+        <a href="{{ url_for('yacimiento.detalle', yacimiento_id=yacimiento.id) }}" class="btn btn-secondary" style="margin-top: 2rem;">← Volver al Yacimiento</a>
     </div>
 
     <!-- Mapa integrado -->
@@ -143,8 +143,8 @@
         <div class="card" style="margin-top: 2rem;">
             <h2 style="margin-bottom: 1rem;">Mapa de Sectores</h2>
             <p style="color: var(--gray); margin-bottom: 1.5rem;">Vista previa de la distribución de sectores</p>
-            <div id="mapa-sectores" style="height: 500px; border-radius: var(--border-radius-lg);"></div>
-            <a href="{{ url_for('mapa_sectores', yacimiento_id=yacimiento.id) }}" class="btn btn-info" style="margin-top: 1rem;">
+            <div id="sectores-map" style="height: 500px; border-radius: var(--border-radius-lg);"></div>
+            <a href="{{ url_for('sector.mapa_sectores', yacimiento_id=yacimiento.id) }}" class="btn btn-info" style="margin-top: 1rem;">
                 Ver Mapa Completo con Hallazgos
             </a>
         </div>

--- a/templates/yacimientos/detalle.html
+++ b/templates/yacimientos/detalle.html
@@ -113,13 +113,13 @@
         </div>
 
         <div class="button-group" style="margin-top: 1.5rem;">
-            <a href="{{ url_for('listar_fases', yacimiento_id=yacimiento.id) }}" class="btn btn-info">Ver Fases</a>
-            <a href="{{ url_for('listar_sectores', yacimiento_id=yacimiento.id) }}" class="btn btn-info">Ver Sectores</a>
-            <a href="{{ url_for('timeline', yacimiento_id=yacimiento.id) }}" class="btn btn-info">LÃ­nea de Tiempo</a>
+            <a href="{{ url_for('fase.listar', yacimiento_id=yacimiento.id) }}" class="btn btn-info">Ver Fases</a>
+            <a href="{{ url_for('sector.listar', yacimiento_id=yacimiento.id) }}" class="btn btn-info">Ver Sectores</a>
+            <a href="{{ url_for('evento.timeline', yacimiento_id=yacimiento.id) }}" class="btn btn-info">LÃ­nea de Tiempo</a>
             {% if es_propietario or rol_usuario == 'asistente' %}
-                <a href="{{ url_for('gestionar_invitaciones', yacimiento_id=yacimiento.id) }}" class="btn btn-warning">Invitaciones</a>
+                <a href="{{ url_for('invitacion.gestionar', yacimiento_id=yacimiento.id) }}" class="btn btn-warning">Invitaciones</a>
             {% endif %}
-            <a href="{{ url_for('proceso_yacimiento', id=yacimiento.id) }}" class="btn btn-secondary">Ver Proceso</a>
+            <a href="{{ url_for('yacimiento.proceso', yacimiento_id=yacimiento.id) }}" class="btn btn-secondary">Ver Proceso</a>
             {% if yacimiento.fecha_fin %}
                 <a href="/yacimiento/{{ yacimiento.id }}/informe" class="btn btn-success" style="display: inline-flex; align-items: center; gap: 0.5rem;">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -147,7 +147,7 @@
 
     <div class="card">
         <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem;">
-            <h2 style="margin: 0; border: none;">Hallazgos ({{ yacimiento.hallazgos|length }})</h2>
+            <h2 style="margin: 0; border: none;">Hallazgos ({{ hallazgos|length }})</h2>
             {% if puede_crear %}
                 <a href="/nuevo_hallazgo/{{ yacimiento.id }}" class="btn btn-success" style="margin: 0;">
                     âž• Registrar Hallazgo
@@ -155,9 +155,9 @@
             {% endif %}
         </div>
 
-        {% if yacimiento.hallazgos %}
+        {% if hallazgos %}
             <div class="hallazgos-list">
-                {% for hallazgo in yacimiento.hallazgos %}
+                {% for hallazgo in hallazgos %}
                     <div class="hallazgo-card">
                         {% if hallazgo.foto %}
                             <div style="margin-bottom: 1rem;">

--- a/templates/yacimientos/proceso.html
+++ b/templates/yacimientos/proceso.html
@@ -127,7 +127,7 @@
                             <div style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
                                 <a href="/fase/{{ fase.id }}" class="btn btn-secondary" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Ver Detalles</a>
                                 {% if puede_editar %}
-                                    <a href="/fase/{{ fase.id }}/editar" class="btn" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
+                                    <a href="/editar_fase/{{ fase.id }}" class="btn" style="padding: 0.5rem 1rem; font-size: var(--font-sm);">Editar</a>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- Templates referenced stale or inconsistent route names and literal paths which caused runtime 404s and broken navigation (`fase`, `sector`, `evento`, `invitacion` endpoints).  
- `yacimiento.detalle` rendered pages without enforcing that invited users had accepted access, risking unauthorized detail views.  
- Several templates relied on context variables or form objects that were missing from views (e.g. comment form object), causing rendering errors.  
- Sector list/map UI expected computed aggregates and permission flags that the view did not supply, breaking map initialization and action visibility.

### Description
- Enforced access control and supplied template context in `app/blueprints/yacimiento.py` by checking accepted `Invitacion` and adding `es_propietario`, `rol_usuario`, `total_hallazgos`, `total_sectores`, `total_fases`, `hallazgos_con_foto`, and `sectores_json` to the template context.  
- Added role-aware flags and aggregates in `app/blueprints/sector.py`: compute `puede_crear`, `puede_editar_sectores`, `puede_eliminar_sectores`, and `total_hallazgos`, and pass `sectores_json` to the template.  
- Fixed many template route references and action `href`/`action` values to use the correct endpoints (examples: `url_for('sector.nuevo_sector')`, `url_for('sector.mapa_sectores')`, `url_for('fase.listar')`, `url_for('evento.timeline')`, `url_for('invitacion.gestionar')`, and `url_for('main.eliminar_cuenta')`) and updated edit/delete action paths to match view routes (e.g. `/editar_fase/<id>`, `/eliminar_fase/<id>`, `/editar_evento/<id>`, `/eliminar_evento/<id>`, `/aceptar_invitacion/<id>`, `/rechazar_invitacion/<id>`, `/revocar_invitacion/<id>`).  
- Replaced a non-existent WTForm usage in `templates/hallazgos/detalle.html` with a simple CSRF-protected native `<textarea>` form that posts to the existing handler (`/comentar_hallazgo/<id>`).  
- Aligned map container id used in templates with JS initializers (`sectores-map`) so sector maps and polygon tools render correctly.

### Testing
- Ran `python -m compileall app run.py main.py config.py` and compilation succeeded for all modules.  
- Validated frontend scripts with `node --check` for `static/js/*.js` and all checks passed.  
- Programmatic template checks succeeded: a script verified every `url_for('...')` endpoint referenced in templates exists in Flask `url_map`, and a separate script verified literal `href`/`action` paths match application routes.  
- Performed a smoke-run of the app with `python run.py`, loaded `/` via browser automation, and captured a screenshot; the server ran and the home page loaded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698889e7432c832a85daae90d4f44706)