### PR TITLE
Fix event form validation for required description and datetime input

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -93,8 +93,12 @@ class FaseForm(FlaskForm):
 class EventoForm(FlaskForm):
     tipo = SelectField('Tipo', choices=[('hallazgo', 'Hallazgo'), ('reunion', 'Reunión'), ('analisis', 'Análisis'), ('cambio_estado', 'Cambio Estado'), ('decision', 'Decisión'), ('visita', 'Visita'), ('entrega', 'Entrega'), ('otro', 'Otro')])
     titulo = StringField('Título', validators=[InputRequired()])
-    descripcion = TextAreaField('Descripción')
-    fecha = DateTimeField('Fecha', validators=[Optional()])
+    descripcion = TextAreaField('Descripción', validators=[InputRequired()])
+    fecha = DateTimeField(
+        'Fecha',
+        validators=[DataRequired()],
+        format='%Y-%m-%dT%H:%M'
+    )
     fase_id = SelectField('Fase', coerce=int)
     hallazgo_id = SelectField('Hallazgo', coerce=int)
     sector_id = SelectField('Sector', coerce=int)


### PR DESCRIPTION
### Motivation
- Ensure the event creation/edit form enforces a non-empty description and correctly parses the `datetime-local` input so model constraints (non-nullable `Evento.fecha`) and UI behavior are aligned.

### Description
- Updated `EventoForm` in `app/forms.py` to make `descripcion` required with `InputRequired()` and changed `fecha` to use `DataRequired()` with explicit `format='%Y-%m-%dT%H:%M'` to match HTML `datetime-local` values.

### Testing
- Ran `python -m compileall -q .`, `node --check static/js/*.js`, and a Flask bootstrap and route smoke test via `app.test_client()` which all completed successfully (compile, JS syntax, app creation and GET checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a7071cf8832ab40d060593514ad3)